### PR TITLE
Break Out Remove File Extension From Camel Case

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,19 @@ esbuild.build({
 
 ## Options
 
-+ `camelCase` - truthy or falsy - If truthy, this camel cases paths and filenames and removes file extensions.
++ `camelCase` - truthy or falsy - If truthy, this camel cases paths and filenames.
++ `removeFileExtension` - truthy or falsy - If truthy, this removes the file extensions from the object keys.
 + `entryPoint` - string or falsy - Set which file in a directory is the entry point. If `entryPoint` is a string and matches a file, that module will be set on the key of the parent directory's name. If `entryPoint` is falsy all matching files will be imported and included in an object on keys of those file's names.
 + `entryPointMatch` - function or nullish - Determine which file in a directory is the entry point. This function is called for every file imported using a glob. It receives the filepath as an array. Return truthy if the path is an entry point and falsy if not.
 
-## Example with default options
+## Example With Default Options
 
 Options:
 
 ```js
 const opts = {
   camelCase: true,
+  removeFileExtension: true,
   entryPoint: 'index.js',
   entryPointMatch: arr => arr[arr.length - 1] === opts.entryPoint
 }
@@ -50,7 +52,7 @@ File structure:
   /home
     home.css
     index.js
-  /about
+  /about_time
     /content
       summary.js
       history.js
@@ -75,7 +77,7 @@ Output:
   home: function () {
     // ...
   },
-  about: function () {
+  aboutTime: function () {
     // ...
   },
   error: function () {
@@ -84,15 +86,16 @@ Output:
 }
 ```
 
-## Alternative Example
+## Alternative Examples
 
-Using the same file structure and import statement from the previous example but with different options.
+Example with all options set to false.
 
 Options:
 
 ```js
 const opts = {
   camelCase: false,
+  removeFileExtension: false,
   entryPoint: false,
   entryPointMatch: null
 }
@@ -107,7 +110,7 @@ Output:
       // ...
     }
   },
-  about: {
+  about_time: {
     'index.js': function () {
       // ...
     },
@@ -124,6 +127,35 @@ Output:
     'index.js': function () {
       // ...
     }
+  }
+}
+```
+
+Example with `camelCase` set to false, but all other options set to true.
+
+Options:
+
+```js
+const opts = {
+  camelCase: false,
+  removeFileExtension: true,
+  entryPoint: 'index.js',
+  entryPointMatch: arr => arr[arr.length - 1] === opts.entryPoint
+}
+```
+
+Output:
+
+```js
+{
+  home: function () {
+    // ...
+  },
+  about_time: function () {
+    // ...
+  },
+  error: function () {
+    // ...
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ export default function (opts) {
   opts ??= {}
 
   opts.camelCase ??= true
+  opts.removeFileExtension ??= true
   opts.entryPoint ??= 'index.js'
   opts.entryPointMatch ??= arr => arr[arr.length - 1] === opts.entryPoint
 
@@ -19,12 +20,6 @@ export default function (opts) {
       build.onLoad({ filter, namespace }, args => load(args, opts))
     }
   }
-}
-
-function camelCase (filename) {
-  return filename
-    .replace(/\.[^.]+$/, '') // removes extension
-    .replace(/[-_](\w)/g, (match, letter) => letter.toUpperCase())
 }
 
 function resolve (args) {
@@ -76,7 +71,11 @@ function load (args, opts) {
       }
 
       if (opts.camelCase) {
-        key = camelCase(key)
+        key = key.replace(/[-_](\w)/g, (match, letter) => letter.toUpperCase());
+      }
+
+      if (opts.removeFileExtension) {
+        key = key.replace(/\.[^.]+$/, "");
       }
 
       if (i === arr.length - 1) {


### PR DESCRIPTION
!!! This is a breaking change !!!

I want to be able to remove file extensions without modifying the files into camel case. Here I break it into its own setting. For users who currently have the `camelCase` setting as `true` or default, there is no change in behavior. For users with `camelCase` setting as `false`, they will now have file paths stripped unless they also specify that setting as `false`.

Let me know if this is acceptable.